### PR TITLE
Changed location of openSUSE package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You have multiple options:
   [`discord-screenaudio`](https://aur.archlinux.org/packages/discord-screenaudio)
   from the AUR
 - If you are on openSUSE, you can use the
-  [Open Build Service package](https://software.opensuse.org/download.html?project=home%3AVortexAcherontic&package=discord-screenaudio)
+  [Open Build Service package](https://software.opensuse.org//download.html?project=games%3Atools&package=discord-screenaudio)
   by [@VortexAcherontic](https://github.com/VortexAcherontic)
 - You can [build it yourself](#building-from-source)
 


### PR DESCRIPTION
The discord-screenaudio package got merged with the main development repository of openSUSE for game/gamer related tools games:tools.
I changed the location of the package and wanted to say:

Many thanks for even mentioning it in your README.
I was a happily surprised to actually see it being mentioned there ❤️ 