### PR TITLE
Fix mute and deafen keybinds disconnecting from the call

### DIFF
--- a/assets/userscript.js
+++ b/assets/userscript.js
@@ -183,14 +183,21 @@ setInterval(() => {
     el.appendChild(div);
   }
 
-  const muteBtn = document.getElementsByClassName(
+  const buttonContainer = document.getElementsByClassName("container-YkUktl")[0];
+  if (!buttonContainer) {
+    console.log('dsa: Cannot locate Mute/Deafen/Settings button container, please report this on GitHub');
+  }
+  
+  const muteBtn = buttonContainer ? buttonContainer.getElementsByClassName(
     "button-12Fmur enabled-9OeuTA button-f2h6uQ lookBlank-21BCro colorBrand-I6CyqQ grow-2sR_-F"
-  )[0];
-  window.discordScreenaudioToggleMute = () => muteBtn.click();
-  const deafenBtn = document.getElementsByClassName(
+  )[0] : null;
+  window.discordScreenaudioToggleMute = () => muteBtn && muteBtn.click();
+  
+  const deafenBtn = buttonContainer ? buttonContainer.getElementsByClassName(
     "button-12Fmur enabled-9OeuTA button-f2h6uQ lookBlank-21BCro colorBrand-I6CyqQ grow-2sR_-F"
-  )[1];
-  window.discordScreenaudioToggleDeafen = () => deafenBtn.click();
+  )[1] : null;
+  
+  window.discordScreenaudioToggleDeafen = () => deafenBtn && deafenBtn.click();
 
   if (window.discordScreenaudioResolutionString) {
     for (const el of document.getElementsByClassName(


### PR DESCRIPTION
In current master version, the mute and deafen keybinds disconnect you from the call instead of performing their respective actions. This is because the getElementsByClassName call was actually returning the "disconnect" button (if you were in a call), as it shares CSS class names with mute and deafen buttons.

This PR modifies this logic and looks for the mute/deafen/settings button container first, and then looks for the individual buttons inside it.

While this may break if Discord changes their CSS class names, the previous iteration of keybinds could as well, so this is certainly an improvement.