### PR TITLE
Do not convert to Latin1 and use UTF-8 instead

### DIFF
--- a/src/virtmic.cpp
+++ b/src/virtmic.cpp
@@ -99,7 +99,7 @@ void start(QString _target) {
     }
   };
 
-  std::string target = _target.toLatin1().toStdString();
+  std::string target = _target.toUtf8().toStdString();
 
   auto virtual_mic = core.create("adapter",
                                  {{"node.name", "discord-screenaudio-virtmic"},


### PR DESCRIPTION
Without this change, processes with non-ascii chars are not linked (e.g. `Sekiro™: Shadows Die Twice` on my system).

I am not sure if this has anything to do with the system locale. If yes, this might break systems using latin1.