### PR TITLE
Qt6 support

### DIFF
--- a/src/centralwidget.cpp
+++ b/src/centralwidget.cpp
@@ -11,7 +11,7 @@
 CentralWidget::CentralWidget(QWidget *parent) : QWidget(parent) {
   setStyleSheet("background-color:#313338;");
   m_layout = new QVBoxLayout(this);
-  m_layout->setMargin(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
   m_layout->setSpacing(0);
   setupWebView();
 }


### PR DESCRIPTION
Hi, this is a small patch that makes the project compile successfully on Qt6.
The setMargin function was removed in Qt6 and I replaced it with setContentsMargin as suggested [here](https://doc.qt.io/qt-5/qlayout-obsolete.html#setMargin).

I apologize in advance for any mistakes that I made, I'm kind of a noob in C++ and Qt...