### PR TITLE
`JavascriptCanOpenWindows` is set for multiple times in discordpage.c…

### DIFF
--- a/src/discordpage.cpp
+++ b/src/discordpage.cpp
@@ -72,7 +72,6 @@ void DiscordPage::readAndAppendJsFile(const QString &path, QByteArray &data) {
 
 void DiscordPage::setupPermissions() {
   settings()->setAttribute(QWebEngineSettings::ScreenCaptureEnabled, true);
-  settings()->setAttribute(QWebEngineSettings::JavascriptCanOpenWindows, true);
   settings()->setAttribute(QWebEngineSettings::AllowRunningInsecureContent,
                            true);
   settings()->setAttribute(


### PR DESCRIPTION
…pp; remove the first invalid one.